### PR TITLE
feat: Ticket PDF Generator with Download option

### DIFF
--- a/flight_ticket.pdf
+++ b/flight_ticket.pdf
@@ -1,0 +1,85 @@
+%PDF-1.4
+%“Œ‹ž ReportLab Generated PDF document http://www.reportlab.com
+1 0 obj
+<<
+/F1 2 0 R /F2 4 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BitsPerComponent 8 /ColorSpace /DeviceRGB /Filter [ /ASCII85Decode /FlateDecode ] /Height 120 /Length 11607 /Subtype /Image 
+  /Type /XObject /Width 120
+>>
+stream
+Gb"/L#CKKNpA^UUYA\a5e79no8S0`ARE>*nh?Z\$d]3WZ#R!G%7;3,f&:P`PMGhA-76qKIhM%%br9q5.QF6-a<nA)Q&G!U1]h'k&@D]7@:X8-N?J^pZH11XEpY9i94m,!3)3dE)PX-1O5oGnQ)3dE)PX-1O5oGnQ)3dG_hif)8?[I7rg%R`+G1=#J0&LnZI"b+_a5@16`.fCH">M'U!C7@&*=G2Q;E1(\8YK*fSshS!Y$(([R[Vg05BQhIHdTQfgJL03oW,Oo=8hOBpBum+lf(Nm$kIqdB$YeUkoCS4:oVm08Q:CQ7?Ki=aHtmjW''Dm?WJ^UPq1jKg0Bg\l@2&12+s$B9HI4lr-iVGl;>_gro.t*Y:o`mmsQ,T!s=ri`6'8,OdDD/17B[,g*34AT-MQg$8NL39H#j\M?YN"!2dT@8d8Mh&XlJVAha"JCgi>h?D,Z1S#dhMb^0sZ!L9fKYNT<^6Z[%7NqTkM6&qM9[5it;Qup)H?]#u[gk$EtKM%p^LEfE(nhP/`am9"ajX7;76roDj%)aj2<.>;iI)f#pLDB_3%1P)f)/N0Q86HRlE6"p)%jQlThDB93U9-k\$_r.7[n&^^kYm2X27.Cu7%O]k)A4PHYlu+U(*G3I(1Sm%TF0%UqADE!8FAA]38>!JI\q74=n9)&`/2AE``FOHXu$S<:!*cG*B(MfcH2E_Bj>!Rdg*Z9L1,jmU@U-#_?+^n=e]I9ppjL$eb#8F1NI*Bp\1kcNPkfh+?4AjkXBkjp2c^)`>K$XP"[nH07\c<#G_OIjGH(A8ZBU":!7-a?X>7pn3$a2KC!MPdXF;Ks6Tm\C+]6b/b*!r$1.S5JTBi\m@.VXp\1AZSeF<&7^73L^-"'jBQS1r*cNq[';>r#b"678ZFH&a]l>;W%@+Y:rRsV=_j3_1O3#KhCW6E;CeH2]>Ff2Y5a'7I"t78BE;Y68J@Yf]45dR(5@&d&:SKN!AH$b'g_>W[$5&r^':S3JVFuRX]ahCZBFI`4;*=uq;\/SY^RV5$irFGp#3icl#%srq.g1C_L;aB9$\OqfQPC@$mJs/L?lf]aCH(U<2E$\[fCpi#=fbWbcnS2f=%F%Y$so%<nPe(j^j[cRB/80'9oM0F7J,sR7T1<6!Xhjo)XG7d*IHI/+jM[3[eUDV(BF"+o*4[fns;k6q_h!BN%jPWS.K<[r)(gg)#PqY]\$tgJrkAjL%hB&`]ph>B=)Zi.@E#<q@DJtU"=T4R-Q[WV"$i:.d@*P$SIiuq>fCo?)[U=5J+1dLm&Ta.=`#ieeUWOQWfX#maM$p*UJ2ZZ$-K3,B27`Y9j3k&%ZSccB;_9!jj]J%4hgTT-m]AS3-`M@WbZVOuRa@RV8JH:C..s91l486gLtQ9BBJ,f8"\b<0kjB[6LourV;qaVKrYZ8B(9BY&=KJZf7U#rW7JFX8g%S,3cuIlrEX6VSlFh$_SN5Z3)q$-<FFdD]VV]A_hX`,8iL_U5`=5jP7jo1:c)uaf[_>6D;\4$NPZ!Mh%?tWEo6mds^jL)`POY`mtfr[d^`>*Kk9I4.P()9:%`%gYc,LQc+)T7;#CMLuiLe1aC?p@1%&:lCeKXEHih"XER&O]\^fNNN3UYVq&AZ.gfg-&"O*1,&"*#e-hdt1X?E3eUfufCEs-U)t=pWH-DFJ%W%<(q^eCaJ2W'$UiE^EZLXocg(BZ*;Q1NLD$Y&2HhXZH>HK6sj3Eh/Ho0=\5R,Gp/(7PSU]'lh*TJgS2kD%Gf0=rom+]8T)Zi+D0+P>N:=]duDI>iik_>QMOHehee7eJ!A[+V[4T%s]Z0YLtgC:b-5&(USF+e"1/%c^_I4i/)oo3EOj#UY)L4AeSpBta6^Q;eUP..Vq`#B^BQB-Xo_;H=K(#'`b@^T36A_HGG)l&C+(NT'`$m5h/%_!ro..P\mPOnmSLZFqT8SkC;e+i'&NMlpY4Qak2JM57T/0!e@W+ZB2>`e6>Us`>d2&4LC[A-th]cKIqEk+%`Qn=PIJ_d)?HjnL\Fef$tZ#C]1``7pT[N/R<;a\d@qp=n]1H]Ni%5`lu$ghYleT&JaqV/&Te>a14H^pXp/sc>&ZXn)=Zc3p_F,JOJhncFS5/LU0)OTh8b`V!63.QU^:?RLlb0(hu0TW\'VF2BZY`,_;.*)jX*LSN]G\CnHkeR:`B9%iKr\O_-gtB#n2QGT]qk$A\_hq/&2JeF2?pLO,i9L5k)22WZdDd#KBOURmM'X76S#+MWJEKC15sA)E2L]k%f$qgP]tG/b)YrG*]-o`IfP83:)E1<b/3shk;cD0#H0_42nt$lNIXZbIJuHm?2iI.@_J[*Y4S-=<9s,^Gs5/@94f]N2hK]k/J8Prg6Mq6u[R+3?'c/XPbUDHj)lqTT;EZWk=6-'jciJ7IhKb@gLEXop]A#`#mJB1RI<qBuBLnu80M$^?bd5sA`[)$DXbb7B_5a?B,mC8H8#Ju?C&"o9WH''8/-=up&=E+A8T+O2mf0ufOg2/OiHbTGb=X'flimQ5@&WnL+p9X7ZM25RO2#f&EGfN[LEIp2S:ch'0@%o)H</;@>e<DDiY=BUD#YWs[5$1MOmtDS+-%!Yr-X&ND3P'GVkCY1n?]Ll<AIQWP'+u##'j<nJ\u6Gp,i)c@W5`MU,9mnLXgOcIc)23KfF8i4Qust+_X#&f["Qi;d]S.%<*Wh:HYpA,A[#(mDj,_aPVI<DU#h&5CY[hX`i_:%&M['I&dg:Y'2kaNWcuQ"h((G1T\;nKg-$>->r^U!d6^H0:eRU=&m\r*$iOJbAamngfgi3DTcW"TZ*RD]F42X?+iX@m*'"]0#6tD^9B=#FmF9h?if`=AAN<eVM9?k*,Tr"M#rFmW1PXmYW;/-R`?t)n<mJ\o)%mG(ce>Udc&jl=b)6$5?X0:n*an5+6k-Dc'!b6Z2,5O1X:5$K\#2%F$bT'Kt5[*6S+pNEflaU>Ca'+=/=CAPKc+(*Xo^.;:"M2Z.D@VASa#=-8]nM2LXP*hoo'/2]B6`lo"`B9>5IH4<,W@I\n76OZ"F-H/-6RTn14/rnQ17/!ba`j<Lu5<f?pOf/\7rg>.0AlkmO]Cqebt38\b<DLOaubfh,gdm+0XX1%I!O>38pY`[,^SO01,!IPE:dM30sM:".p5XA_`E2b9HheFZL$_YlIQMJA/[8$>]I#L6N;=,&bY5na'J^CM"$"5gcgg^D=0t;PJ3S\crgE$\dGjFm0I_A8m?Z!_1bn1Wk*:aI"%k,^g@Rq8g1.]<[XgL2[BK$k*8Z2hu#qatB:KVbk?6IP<bj>/VL[Q/V3PtHt34BmpD</*!@Y"Xja1MgeQ9nk'Mli@)@fU-B$4<g\N#U%U"gHp_+5Gu8C.XNk\I%;;$dOa*2EO)"936LY@hsB4>!dn.T*Vp$%QK6*mnV99"%d#okoa>29On8<KJYq:cb&q&GXH)+3KM,aUEi&RoXst/V!78a/T(O8%Q1`QqS(@e.ouCd)YcmIdI"B_)1JoCYe!:m76R;F@LMb,8,k:q3-BajL-eFf<FsWVkg!=pm@V&-*13/[Sm9*N10EGRdG6c6fZA?b=@-<OI!,a%Xoo6+O3YpHlA*P?Q-33E*sdfQ:7hL*rcL=p3h1;"q'M.Vrf0K)\r+\e2#\(+Rl%S2Df#GK0,6Gfs#D)X*HX,D+>9F_=`3]0LkGX"p\nU+Q<C>$/:N,lp+q!NXXb)[+Y8g2'E`Xg)!PcFm/LBbr;%8tl6Tn<"!.I^-uC!ef7g]mZpnGK)O`O:^EbZ)j3=:rV_-U)e=i8Ke$TmuLP?#c,3X/CRJL%(E<[VL#IJK]=Pes3V/\gtUOc8=4SlieotaA>IiW-+]7_JMKjme>,Od_<1WS\h5:-*nBc7i(@Ws(1G]nBtSCn&Z7u=uf,[WQ+rUMZ@K71tjT/e9k&aWdNhRQ8NluM@>%k9Ii<ifT*Gk>;gcuk82:HbZ3[R0i]UZ+X:MVd('qqE1cB5]K<5=PPD/b6;BUitFkGfiO4Y]k^:'`kMUa5lENP/`uS+s4Pr_aBn)@YuEhRtefPX`RA0pF"o>l\T9LL"RfDhJTZ%B8k:-HU@APIa6$?6it8%@X81j=$b42j<#).][")p8&RA/Z$DY$oL3^;kI,AG-L+'c-0,3Qf&RNa5#S50.rm@iDCPl@i$"NU+gO3u[[Y?YP?@;p.bhl!HJ!g+U!04YUa@GBr,,.rIc?T#L*_%X2_8"t=Xu\FNVC7QeorKT^L&+4p_kY+_%%H!3]BF+X:WRu[QT+"Z8b(\FYDD<`#2N*^M)D!j40'`la>Y+M3lQ9cgMQ!StSf^V!u@+pinl)kU*XpX>ecER=73;@l<#,gne`[1["$lR+NAro@odnHhf4p/2%U/q7t77@JG?cR6Df&.Z*75Z/H1Dl%rh8S4P7;30f+FgB5e,mspH)$njpLl9hN&QL4o`B(4T'R8Xo7&%[t]GZ+&&GtMeBM8\s^d<(tiKZO>I6QK="1NUUu'oli5dK.Vn^_QUB@@IU:a^RuGT(p9oN2Mu`Zi.uc6!=[1:1JiZO.kqe_3Z4&-?]/5rL)hn^VVhuG.ENZic$];OmBE:bce+3U;Aa+q./j;6>Tf]Q5q0m)fKg,0/JZh0TE7kh)RN)`]3"kabBtC`\3brGMb6*c.'7M-6&kC15rD3!%kIW^msAmUtTWSUKsa=1&8%69GnoOh/Ra>4_`au*LR)EBXT<2+U=I)RNdZ2P-)ru;Te&*-lbI0kBZSp.Hj/\V8'mMj?KPU0<LKLaZ&h0Xr&LYP8?_.T0OYW4]4`6kTP\uIhMa&NWRI5>r[b>QT2H"S3r3SM>6OLN81'DrXc-$[c5O'WjGNngM43#PEW))M(+/^Rk_aNOD$G>^fr6GS(6Q)B)7^LF-<P]'?=0%cC0j!n?08+kJXKmYCC5/gubH5YE(EC%/-&_%k-\@)pTN3EY4!(m'`[O`EB%^dHL10Yli$"P.:Q?4+"1CD7kOqJah]&lG4je_b1VmM'au#_IO'oE8`^UD>#rAf4?"(Cjc%uaa[)`nW(?,cE;4@F:6/TY?mka1fHd%GY%1%?oomK$OG3S^bhpjZFg<R;Hht5q[DsX31u&PF`W7N@k%mOS>$+IJV=6.33Z6]hLo2l5<D)ZM(a:'A8rAW16h'Oi6hU/C:'"F?F`@\%^IpEr,eP$`b'3jE?\J;=V;]eMf%&aq>$Su[>SMcdS8i6`bd4O?QZ+Q?$s]bjt9ns0Z`1h8NZr#'hVcA`TRqC1,-RM2kB+4*?p]6`o<o$"YQ`?-X5M>$%Q/t1&,H>/tf-^mjN0[*Q.@Zkh[#3p!O4q/H$2V'nJ0RpcM?PE)JZ%)D>$_*j/=@7M]W9O=lj\!,$r.nlq8oT>/M3ltWsR,jrfama.6*e3.Rn^rZg5%N&p\$b5%E?h2[hjDXE"mT?S.?"#/-1Tjq-s):3/Ymu*9SVIh0"Vd'Ei2UQA]@KM_26!gd_oUUNC1&d_2Z'TGL,fnV^`_6&M-kM*%f!h4An[OfX^*hh]Aan!Wk"SKo5q%rl^,rFhEN7aSdC-5mkB^$:96!A0$Z?srK@fFA8k>^[l?eNgT)<Rc;*MHWOtomW_0FoMCd%p?90R]Ud1Gu*iJ\c'@]3J</fR=+(m]UIr(8s"n_6`D;Z&R:j5g3D=.Q*rr80'fHaZV>s"o-rh8$1[rueqerj4KaQE>`Q:dd!]ubNgDN.'P+>UQ?19N`Z>--F$O%knuWWZTHg]?jleYsHmW]n_"Qsd7';VZGRf9MR6Ya"7;``3sZf;QH9ffm?_`A6@$5!$K<2qVLf/2rb?0&qd],E"@/T#R+/@6"-?rKdJTkq13*%N*4QHK+gKfent8EhsEfD72*PjTFmL-ug#7QliJ.+4qjpon\"A3\4FF^3O\LW\H`.VS9?:P3u&=^c(%,NS@=!L&D-2_H7O#1r:;Mlbe\aZ.1UVE;PSJ4>`YqZ%^>9[;]s4[UfK05CJ/m9!i$3kY+rPb2O1*(2&;2'?\1>c4*r0T;D2%f51p0&u'f^Q@.[0@7dnaNeXe?QA!&(E%0?2]Q>r;plg2hmp@_/[uK;7,3Q/AdEi9V,FaAtf>Qf_R!9f&!I>R<_M]Lt_XXi5BqSfEa^)2SLK`lfa/8uu2`Te+@%/'IYfF_\C@t>)XAbj4$D]:.ecTCt@**&BMuW$([A,%dE;o#4L=KaeAfo:U$HlRcEMRSL'hAAN!H8@<EEtb$m;q1e1E^r()DH9jStnN`0NPBd"&cNf"tU;%J3?*[P*l/(^;M<t3#!2>R"l++#&NM^l%-a>AbMP:WATm!$`CutSe8_Z<nthX3adphR&s^N.rOV<\7KaR/*CXgY#2<(TNO-Z^SXL#a9(1m$e=R0W*WXTr<BIoBTFj]rSfNeP+7+-U&iPN9JjV6#%u5FAE,WS4dPP4;>M:UC2Dj#*U2!)reOGsTMQ&l$\![sN@?^H4TjGA_/5@VSD[.^KJ)1a0Xr_rRKggjfPm=;\q,pYJ0'LS%*o(i-b,jB<U/XREECF_\oKR2N/eJ?n`rkYJdnTPF0iBN;DpbV3&CBp>]D)*ZPuZOop]I`Rgd5DrW<Qi>s:X1r.#tG+XK8%!7!qR+`4,n2unUA1EAMg?k<[,'Zs[c)IPMjAogRBP0KL"`[NfOS5#c&aApSr!)JZqEQ?&O:Hg;mdU-jm""jh;q#,U_)[sW8;53Zf"k$#:FD,3)`r.rS1Y\O4[XE=TH1M'_eo=2cb[4`>9H%O$MUR+C-$SegpL')>E3TI(\d/.,0\V(Z2K,=-dh:bXlc!f0i4nk5qVcnskD,H)4O!`_0_<bGX:JZJ^\8YEi?dpFmJK=I$?n]a4nTf0Z*'u-$#g8=063;^:+Sa]>HSm<:dql":*@iH`TGWWn[i/1EW0NFlSt^eU>'$U@pNV.iTKeHi(F29ae2oQYlQr)&D+@AMrlUZ*?OtU$P0gJI@R(<..OQh<CaOf5C&gmj#PIbj)Nf(fQ+;2_D1=PRn35,J?I,tY#*_Q%H'<<T,)ti/s^"//Ws*AAO@Z"ZV".)'JG"R9%/f='nC@@H_YM6d]Jf*+l\hYR#faqN(+bSkohoSU+":65B=q2.i^,QbFB<$M-H;shKp"9q(52U6bLb4WeC)cg61+8REodbG!.$Zn_@*n8)r\J%+B?RiK;)>0tA2NYgNMa-I9$sO0Xd%Yb<s:rSVjD\;(=>JJgadNes+F>sq/L\)]6gGZ5$_oWn;\d1sZbcNmo@WXadCnT>8/*Ll3bd\kP"KlQPO&t0_pX649&DU\pX1P.<Xc\c[)7:+BK&U2H-o/!Ts*IJCAd'_nQgOtapUq?6b-+tJ,l]L'X:l]?(<>?j$Ke?b&aC/P1/IWO"43X$N?[>r]UEVBWMT7kt]$r,jfo9>?mUNV1k-[7uPS*HDVl=?[--/U?OcPF7o#aN,M*lt71i0J0\g[*8$fn`QBFM:'CH"6[MoV,<2uCY%e<_5?B).Y++<C)rP\*,>nbE<_p#r"NE.sKKKU]q@e='5GAkUdCCJj0i1Xlh?&r]%rK,d`3SX1-qOFaLjp]?02iCPe=.%H&e8[a'@-DS2en)cE?)k4H1D!4UgqA=:krNS8]Q&89R['6";oYe`%[]Pe2ok3Po-\?]ED5o(SEu,eL5i)ETTKi;=.ibZD(&U+PRj"#]n>4+I=71kqc3kHeT2;+.;ruH<!FRt,;V1H:"^!4rN>#0,QJ6Z>Y<M+/"3fkJ1^OJ3k]/Aj!-@(*@DO.#bs^CND_RVm`;9/%+[Tt.Cl`Z4>2D_l4XpJBH!!YSc-jTBe&Fm;.#LZ\F\&gGSB2;Y1.I:Bbrf!)W+2+2!9JmooYq^U(XRDGQHkqh!_*q*D;80EXk."7ZVL)7"\O9jU!9ZM='\L0-t^amCsn4$B+(BOW#E'W+E4Jd\.1eqB_/1,4P+]:*4=tJTh#9G),.OdIWCPC`;QriVhN)_"$R$MGVHgYZ"rXo\BpjF(rQn-]rrZj?Ji=n78li\fS8[ajaM9&k"A>o_b&K'=&_S"Ag)tQ+E5WL^PgA293&OtXGU3IB_XAE+9_*e0<QT8%"A&RUPtaZj?j7eV$\S.D%5MK3h?6K]/9!CiEX&aL?UF`/AR6^G]T0b/'`(R*.F>0Peena3]C!;/.jB>n%EYW5iB:dgHL7h/AXH%ab*nV%J?f.W!$`(7Y0d;hhW65+1;lB?cOqZIQUCd]:F07e2U*A$A7Xkclq+h]m[oa\3j'_^H"c!"9ZOqi4VctBV/Xkr>)AEMO"Z3?e!E_k>i>QB1WuV<:f&n@7<1X"MJJ(bF]_1It*X0FN`uV4&!q+`uB@Gq9sttXXbO-'sS5mbDX_0>bTX68A9;Jk0R_M/D`#rW8T;8QD?0]Vi)MMq@\PW&$]s%'Jd+3"BV+SjlHuFfNf`Tr.%1tKBJX1--h,^nGlX4C=(\\8.rd<mH5pb?JmuZ5ZO%Y<b\)>*CXXJNkgpMPYtMGY]PV3lZ27+NPZ&bd>$KDcu.Fh0=-+VX*kb-W3*fHe'nr8FX7lBA(05g%%4\/U+@9CIK5^U4L"j]-)KD[Y@R7R_2j2nG=%SRf*dhWoJh9JI]piqGRM+I^[0os=f*#le<jdPZNY%K*K]&NB#6:7=QYhs*O0A6Or:8MkHK(qi;[9@[XML1k!,a]"^+F4JY^)mM&_%u07DQiJ_Ve#$H"HYA^Rb"WES\jI@f1M?o[&6id%5NhePfU+(?:?9!i3EAn61]4XEOsE.Rul:isNQh%+.s*LgToEm_?&4!0c^65Rili+@cZ73#a=6;oeh.,VMpnRQEHWae"YOH.@Bk"X?4X!QWJMen'AT[55'J#fDnH'DIDMmmQ2I+rDTjn#i38%$TqiQ-4UB_e'.&p0TFCjo]%nU22=kX,GZf7q'JqBc?M8<qQ<"-hC&luat#Z-:s9<d+5#iQWWd%QJ[e\I``'r7ib>7gR.cF>QWA+2[.TnV!#8CNM!_$Qh0-b3_r3V)'O(+NQWi=Ssi8C!bUq3#/2ijUIRZgl+(F"^@$EJ-tm;$sW'hS%*<^KQD-['HNb)Ppg]e>e&ju8E+skE="V0[aq2qKnR.Cl%UqFmQU#R^p*G)Z'SPX879(tj*7P>5Fn.;cj\l+Mdj(+Se16kjtD,#i>u-*2@[WRBsoZHeaee"XICb6klT`0C+t"9EpZ6-@9:uZpd"`7Aq=3T$E(<m5u_(hY.C9NqKj<5F";57@PjDRY=#-:AFKZ1opBnm*:R5q>i:SjN<OdCrE9S<*PTuODV=HQL5q05oQ9SWNh\gHQ9ThNj\JOhQ9#F.q:YUt8u8u?ko"o-5mB)km`Hp.mm7S>:mR)bLoA]!e:Yo@Y&!=7O&pES/*g#HNO0)XoT#Z*]j("Lr6t%gq4L;c3DZ&$.LqUH/ejBj<YQ/p*cT5^Xl"QmECO=t\iVXW_A=2GMUEs+&kPQFrN.)&^kXPniol)>;/4oRcG$HJEhiNd\QrS]F01JppnClN+:VP1.NK8eIJ&qfdsMh+c<MA)ODtj_El<hD]s.Q5od@(ng&@ds*!D#-?bT$'fmC&jBUO&1dt/,/oMXu4kjRVU&p^Pl/pkn61\fYn->5,mjp9:KpJlCNE!ZH:3Mbq&3Y/M7)!V]E`ikFX^`]oVXR91ph9]F!g<a#Nh#j[j"LdXq&\G0)oro"ua;0?C@#+%NZMb2<L/Ls%$F:%<n!7U]s1!`=;jWLaZN0>_<&o'%Y_%aY-WS4eqfmAAbMKJ+/T9C4c#tc;6.%kQJXDYI$Bp\?,Skb=#(rBt<obJn(DrBr*-8_Sh'T=MRP0*Uh_&4L.<=Wc&G(T<@ttu;J9/+P1Tf!h\;!'$Kn3LN#;Z+n<e1F+$l>,*F#!mH>Qg2O(/6;/]tG3K:N;=aE=A<sB=Uj-7DnsiJ9Gpul0[:TrhP0QinUj!>T:n6Z5Y__@"bMQou'ojL_G_jI)UQm?jL>j>IM.5])q#eNGB>nCo]C]8qV[,*+:0XGTeeiW@?E9Rt\(K$*/AcpEYdU"4AE^q[GD*^b6MFS,OO3Wgl&4BkW5d<q+u'hm]DA[Q/6uWdqdIXkOB+C@Y?8!fOaT.h(E1RZj+FQ,^(;Z/VZ;Pibujqm0`s`3lQFq;O)Lc3-:LqlqIDrH)qg:_$u'<p+-hlI]dffom,9b`Kg+W-*e?V:52PI/MtKJK]uf4/L[#_*0b8T*R#lIhl[Q86:VDJi)&@:2K%T"O%Pi>d0[@#r5oe<'Iep=(&,c48,FFruGr-D_(m$6Xi(>WC=)FpliRFP#u&&eaiWQfhY_er:Nf\V.jEc3Xj@Zk%Wc>GC=ai\SS]XV06<DG/GDqP-*/t+\6?Vg%7Q'UhJf?#>)4%\NHVu,[R?#AdboC&8IR>c4dc9<#@7UjB]Ag_UaO'HmlBQ`MX2U/t]!.IS:aR,h"^o12`2a)5nf6+h=$daM)urZf9ES03p?[P*J+G_\:?NH0ImLeU2?Hn49P26JOu+8#((R9[pcS+r?so6CM)L@o_Ecd(=eq>R5&hW!P+tEoekF^a;oiTa;I2iDkY4G*'\hOsl7Ohn)@W.g9Gf"+b,qek[/@FtnPaf,Mn`%?[^^g&+M^#C>"+;OHRrku)/Rd@]:<#9^gi;!Qcae9CqOQ&^o3l8f\T^fOcT$B`%`7c403UnYXMOLRhTlk,?KWAL#j8O5[@-%]5]_$NTSYbfN%7iSS"P$K^\pA2fDQ/9L@VV@Yc#\Ei$ae[S-+rNRicmt5?LZFl34J[4O0Di3dV!o!Li?sNq=rmstG,3U>G1>"'ULjmm@-'i,F$'.-bu2.o(,k'0Q%d)/3e=!_M"286+mY`P(orA:6_&PUMJ.VV0j4Fi"u>#(?j?OK(sUSt=WW3^JH\D[9B)_AmeD&(aE#1^%k)1:EPFY3^C!Y,4^902VDm+:.APkmMX\O>_XE.VPef;8^Ki,blS/:u1]3O4W:D^f;M>cG\0"o]"<a5[&a%0aAHg&ZkhPO;U1rbSb(nUJDa/NO9,Td<52_JKXrK_5)FHMdSAX=e9+hL@C9SUe.ORrjFEj?J'<:%ncVoBA%p.'0bPq',qKKuZ=3aWl4@cp`oF1E)'9k-[1#@>4IJPt\Xu3M]GH46")H&+eJHWdS!PJJ>?VcB:dDQTV/^)5(8`aKm"-X$jcYEd37iRM?Q'*:Jb?&M@eX(g&H?./IZ+L&Ok.mKM'VC_CVAkh,_`Cp2K:=3P3jh"qZJ"M::!WAWAI"F)K#sG[A65eMA4h^/g&S@!e4!oZnTo$X0+?55C"sh(ON!P%W-"jdQTrdTkGG+N!3X\Ke_?gX_6&pd3u.j7-RMj!\/F5$_-ATm(@hICq3c=]S]:1unS/b?^P5fsHJl(SXfI]%g2OP-&fY2``eQ^@1e:%9]U;HB/lu;VckcM2it0-SM_3.'S?C6S5I^5l[')PPZ>Jdjf$oi4,8S:gauK;m"OXg`'BSKli!]UKZZoU]?94XH5smH,BK?;.*\.05F:;&(MhYim\Ckt1%YL+giYV+&"\NXNe>Xs\(nX?en+)Kbji+![<V)r5Tsoq"4&PH<T=!_5]h\#URAuXnb<^r'9$X%m72n0bTdgk7MqA*h)<NZ!q3Vr%GQe.?M*t2a<L$=H#(-VR$mV5naGn`9V.[^D\!$=:/#7I&adYfd_=h@%_oL?AOQIL_NA"A3b63tp"uhmoae8`Hk5o4fGlgRB6s1j:'bjZl=grDFOn4o[o4LPioESr(#%^U8AP`SB:^1K-#%^U8AP`SB:^1K-qChjje4#KJ~>endstream
+endobj
+4 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+5 0 obj
+<<
+/Contents 9 0 R /MediaBox [ 0 0 612 792 ] /Parent 8 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] /XObject <<
+/FormXob.c669df6f785b216dbd3f98252dfd884a 3 0 R
+>>
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+6 0 obj
+<<
+/PageMode /UseNone /Pages 8 0 R /Type /Catalog
+>>
+endobj
+7 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20231031224117-05'00') /Creator (ReportLab PDF Library - www.reportlab.com) /Keywords () /ModDate (D:20231031224117-05'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (unspecified) /Title (untitled) /Trapped /False
+>>
+endobj
+8 0 obj
+<<
+/Count 1 /Kids [ 5 0 R ] /Type /Pages
+>>
+endobj
+9 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 876
+>>
+stream
+GatUq?#SFN'Sc)J/'c\P<Eb3L%g$sOJ>T:fXNSS#S\tik&t:qZ("7X0:4gq1$C.8.O=9ldIa<B-@fd^#8GAV(!0[NiErq"];?.$Y!0V,b--h/'7`.4T$+Ot/oYM3M,EId-!kNJa(ER#3E(!!5Qs;U8*/gOtMkWAUlc*D\K/3qJB=rp8NOQ!4#'6X,?Rg3)-lV29<".e@V'O44gb2,O%;B/0E?$["WpLeEAjF%1m?$7J212"#ZJogPF<r2f`M7G3g>qZ<8:EpHd0f+oNOheR0!taf,AH?G@0BH?L!D2G/e''Mqnim@KA"jMXZ$&MqUW>]bViINMd*E_iNhM_DHY6)#IM1^U#$1@]37i!KC9GE8#!?gaB:*p%8=-TP,HJM4"f<kl]g^V<*Kk*:6RqMBis0IT-qDb?6DJI>nS'JlpEbdL/7W&BsZCH10Z2EcLBh]27l%Xa)DuEWO6t]eONS@dcBiYF;<cK)cL?.I)900esc#P?8s'<5X"B7ouEYZfBM#e?&(VBbgO/f=d_e*<G%SjD']QAZF>u,:e9J,pU+/\IH*X2]G6+QF`!MmrAM<hMcf]eY3Q:o\l(:"7OZrK%l]h5`qi#,8<t7>2C6b$<:[*;9K!(+/?QF/*7;4u(FG%(>f[OM/62jUV&Bh'6S7B1I?F(ei?HJBj`VVY\!E(K<gKiJ:p1f?/73E#(^5oobCRbTSp8l71iEd<U.b5?f'\g=KrZN;mbNEAO>30nWa]6be8,4RAnqhZkO5(FfqAd4.M[27+_dd,1d(5Dlm/JK?ZS=[g-:sUL*Koi9d`-4L)lo+f&u`ZR>nI>=II-MhA-Bf`2'Y!*7_[*W&R/NfD%4*86$?J'=_n&cVh2TFb,>1"m8+*'FZD~>endstream
+endobj
+xref
+0 10
+0000000000 65535 f 
+0000000073 00000 n 
+0000000114 00000 n 
+0000000221 00000 n 
+0000012020 00000 n 
+0000012132 00000 n 
+0000012388 00000 n 
+0000012456 00000 n 
+0000012752 00000 n 
+0000012811 00000 n 
+trailer
+<<
+/ID 
+[<1dc2b5ad0a9571027b55ec2f69134ce1><1dc2b5ad0a9571027b55ec2f69134ce1>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 7 0 R
+/Root 6 0 R
+/Size 10
+>>
+startxref
+13777
+%%EOF

--- a/handlers/ticketdetailscollector.py
+++ b/handlers/ticketdetailscollector.py
@@ -1,0 +1,67 @@
+from handlers.ticketgenerator import generate_flight_ticket
+import sqlite3
+import shutil
+import os
+
+# Define ticket details needed for PDF
+dataRequire = {
+    "passenger_name": "",
+    "flight_number": "",
+    "departure_city": "",
+    "arrival_city": "",
+    "departure_date_time": "",
+    "arrival_date_time": "",
+    "ticket_price": "",
+    "pnr_number": ""
+}
+
+# get all passengers details from DB
+def check_passengers(passengers):
+    passengers_details = []
+    conn = sqlite3.connect('./data/database.db')
+    c = conn.cursor()
+    for x in passengers:
+        c.execute('SELECT * FROM tickets WHERE ticket_id = (:id)', {
+            'id': x
+        })
+        record = c.fetchone()
+        passengers_details.append(record)
+    if passengers_details != []:
+        passengers_names = []
+        for x in passengers_details:
+            passengers_names.append(x[3])
+        
+        return passengers_names
+    else:
+        return None
+
+# copy the files into download folder
+def getFileToDownload():
+    source_file = './flight_ticket.pdf'
+    destination_directory = os.path.expanduser('~\\Downloads')
+
+    # Create the destination path by combining the destination directory and the filename
+    destination_file = os.path.join(destination_directory, os.path.basename(source_file))
+    
+    # Copy the file to the destination
+    shutil.copy(source_file, destination_file)
+
+    print(f"'{os.path.basename(source_file)}' copied to the Downloads folder.")
+
+# function for fetching all details required for printing PDF
+def fetch_ticket_data_for_pdf(booking):
+    passengers = check_passengers(booking["passengers"])
+    dataRequire["flight_number"] = booking["id"]
+    dataRequire["passenger_name"] = passengers
+    dataRequire["departure_city"] = booking["source"]
+    dataRequire["arrival_city"] = booking["destination"]
+    dataRequire["departure_date_time"] = booking["departure"]
+    dataRequire["arrival_date_time"] = booking["arrival"]
+    dataRequire["pnr_number"] = booking["pnr"]
+    dataRequire["ticket_price"] = len(passengers) * 2700
+    
+    # Call the function to generate the flight ticket
+    generate_flight_ticket(dataRequire)
+
+    # get the file to downloads folder
+    getFileToDownload()

--- a/handlers/ticketgenerator.py
+++ b/handlers/ticketgenerator.py
@@ -1,0 +1,99 @@
+from reportlab.lib.pagesizes import letter
+from reportlab.pdfgen import canvas
+from reportlab.lib import colors
+
+# function to generate a ticket
+def generate_flight_ticket(data):
+    print(data)
+
+    # Create a PDF file for the ticket
+    c = canvas.Canvas("flight_ticket.pdf", pagesize=letter)
+
+    # Set background color
+    c.saveState()
+    c.setFillColor(colors.lightblue)
+    c.rect(0, 0, 612, 792, fill=1)
+    c.restoreState()
+
+    # Set font and font size for Title
+    c.setFont("Helvetica", 20)
+    c.setFillColor(colors.black)
+    c.drawImage("./assets/airline.png", 50, 675, width=75, height=75)
+    c.drawCentredString(300, 710, "Eagle Airline Pvt. Ltd.")
+    c.setFont("Helvetica", 16)
+    c.drawCentredString(300, 680, "Flight Ticket | E-copy")
+
+    # Passenger Name
+    c.setFont("Helvetica-Bold", 12)
+    c.drawString(50, 630, "Passenger Name:")
+    c.setFont("Helvetica", 12)
+    temp_x = 200
+    for name in data["passenger_name"]:
+        c.drawString(temp_x, 630, name)
+        temp_x = temp_x + 75
+
+    # Flight Details
+    c.setFont("Helvetica-Bold", 12)
+    c.drawString(50, 610, "Flight Number:")
+    c.setFont("Helvetica", 12)
+    c.drawString(200, 610, str(data["flight_number"]))
+
+    # PNR 
+    c.setFont("Helvetica-Bold", 12)
+    c.drawString(250, 610, "PNR Number:")
+    c.setFont("Helvetica", 12)
+    c.drawString(340, 610, data["pnr_number"])
+
+    c.setFont("Helvetica-Bold", 12)
+    c.drawString(50, 590, "Departure Airport:")
+    c.setFont("Helvetica", 12)
+    c.drawString(200, 590, data["departure_city"])
+
+    c.setFont("Helvetica-Bold", 12)
+    c.drawString(50, 570, "Arrival Airport:")
+    c.setFont("Helvetica", 12)
+    c.drawString(200, 570, data["arrival_city"])
+
+    c.setFont("Helvetica-Bold", 12)
+    c.drawString(50, 550, "Departure Date & Time:")
+    c.setFont("Helvetica", 12)
+    c.drawString(200, 550, str(data["departure_date_time"]))
+
+    c.setFont("Helvetica-Bold", 12)
+    c.drawString(50, 530, "Arrival Date & Time:")
+    c.setFont("Helvetica", 12)
+    c.drawString(200, 530, str(data['arrival_date_time']))
+
+    # Ticket Price
+    c.setFont("Helvetica-Bold", 12)
+    c.drawString(50, 510, "Ticket Price:")
+    c.setFont("Helvetica-Bold", 12)
+    c.setFillColor(colors.red)
+    priceText = "Rs. " + str(data['ticket_price'])
+    c.drawString(200, 510, priceText)
+
+    # Footer
+    c.setFont("Helvetica", 10)
+    c.setFillColor(colors.black)
+
+    footer_text = [
+        "Terms & Conditions:",
+        "1. The ticket is non-transferable.",
+        "2. Boarding gates close 30 minutes before departure.",
+        "3. Baggage must adhere to size and weight restrictions.",
+        "4. Changes or cancellations may incur fees.",
+        "5. Mobile or printed ticket must be presented at security and boarding.",
+        "NOTE: This PDF is for reference. Please use the official Eagle Airline app for boarding.",
+    ]
+
+    y_position = 150
+    for line in footer_text:
+        c.drawString(50, y_position, line)
+        y_position -= 20
+
+    # Save the PDF file
+    print("Data Maked")
+    c.showPage()
+    c.save()
+
+    print("Flight ticket PDF generated as flight_ticket.pdf")

--- a/handlers/userbookings.py
+++ b/handlers/userbookings.py
@@ -164,7 +164,7 @@ class UserBookings():
             details.append(f'''Box3d:
     padding : 5, 20
     size_hint_y : None
-    height : 150
+    height : 220
     orientation : 'vertical'
     spacing : 10
     MDLabel:
@@ -174,6 +174,15 @@ class UserBookings():
         valign : "middle"
         height : 40
         size_hint_y : None
+    MDFlatButton:
+        text : 'Download Ticket'
+        font_size : 35
+        height : 40
+        md_bg_color : 'blue'
+        theme_text_color : 'Custom'
+        text_color : 'white'
+        pos_hint : {{'center_x':.5}}
+        on_release: app.button_handler('generate-pdf',{booking})
     MDFlatButton:
         text : 'Cancel Booking'
         font_size : 35

--- a/main.py
+++ b/main.py
@@ -29,6 +29,7 @@ import handlers.getflights as GetFlights
 import handlers.userdetails as UserDetails
 import handlers.userwallet as UserWallet
 import handlers.userbookings as UserBookings
+import handlers.ticketdetailscollector as TicketDetailsCollector
 
 # Python modules
 import json
@@ -572,6 +573,10 @@ class MainApp(MDApp):
                 self.booking = objs
                 self.userscreenchanger('bookings - cancel')
                 self.userscreen_bookings_cancel.ids.user_booking_cancel_heading.text = 'Cancel Booking : ID => ' + str(self.booking['id'])
+            
+            case 'generate-pdf':
+                self.booking = objs
+                TicketDetailsCollector.fetch_ticket_data_for_pdf(self.booking)
 
     # Input validation when button is clicked
     def validate(self, type, obj):

--- a/req.txt
+++ b/req.txt
@@ -2,3 +2,4 @@ kivymd
 kivy
 datetime
 functools
+reportlab


### PR DESCRIPTION
## Updates

- feat: Fetches ticket, passengers and flight information from database.
- feat: Generates ticket using the `reportlab` library and saves into root directory.
- feat: copies the generated ticket into the user's system `Downloads` folder using `OS` library.
- feat: implemented proper functions and modules for generating and saving the PDF.

## Screenshot

### Download Button - Ticket Details Screen
![image](https://github.com/Sanjiv39/airline-python/assets/98116504/cb8c5f44-8036-48ea-8477-6551d27691a9)

### Ticket PDF Generated - Sample
![image](https://github.com/Sanjiv39/airline-python/assets/98116504/e5651870-c41c-413c-adb8-5659ec9ae8ca)
